### PR TITLE
Move from Github packages back to DockerHub 

### DIFF
--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build-and-publish:
     env:
-      IMAGE_NAME: service-layer-data-api
+      IMAGE_NAME: data-api
     name: Build and Publish API
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +30,7 @@ jobs:
           path: ./data-api
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: cloudnativegbb/service-layer/${{ env.IMAGE_NAME }}
+          repository: msftgbb/${{ env.IMAGE_NAME }}
           dockerfile: ./data-api/Dockerfile
           tag_with_ref: true
           add_git_labels: true

--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -28,9 +28,8 @@ jobs:
         uses: docker/build-push-action@v1
         with:
           path: ./data-api
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-          registry: docker.pkg.github.com
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
           repository: cloudnativegbb/service-layer/${{ env.IMAGE_NAME }}
           dockerfile: ./data-api/Dockerfile
           tag_with_ref: true

--- a/.github/workflows/flights.yml
+++ b/.github/workflows/flights.yml
@@ -28,8 +28,8 @@ jobs:
         uses: docker/build-push-action@v1
         with:
           path: ./flights-api
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
           registry: docker.pkg.github.com
           repository: cloudnativegbb/service-layer/${{ env.IMAGE_NAME }}
           dockerfile: ./flights-api/Dockerfile

--- a/.github/workflows/flights.yml
+++ b/.github/workflows/flights.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build-and-publish:
     env:
-      IMAGE_NAME: service-layer-flights-api
+      IMAGE_NAME: flights-api
     name: Build and Publish App
     runs-on: ubuntu-latest
     steps:
@@ -30,8 +30,7 @@ jobs:
           path: ./flights-api
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          registry: docker.pkg.github.com
-          repository: cloudnativegbb/service-layer/${{ env.IMAGE_NAME }}
+          repository: msftgbb/${{ env.IMAGE_NAME }}
           dockerfile: ./flights-api/Dockerfile
           tag_with_ref: true
           add_git_labels: true

--- a/.github/workflows/quakes.yml
+++ b/.github/workflows/quakes.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build-and-publish:
     env:
-      IMAGE_NAME: service-layer-quakes-api
+      IMAGE_NAME: quakes-api
     name: Build and Publish App
     runs-on: ubuntu-latest
     steps:
@@ -28,10 +28,9 @@ jobs:
         uses: docker/build-push-action@v1
         with:
           path: ./quakes-api
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-          registry: docker.pkg.github.com
-          repository: cloudnativegbb/service-layer/${{ env.IMAGE_NAME }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: msftgbb/${{ env.IMAGE_NAME }}
           dockerfile: ./quakes-api/Dockerfile
           tag_with_ref: true
           add_git_labels: true

--- a/.github/workflows/weather.yml
+++ b/.github/workflows/weather.yml
@@ -30,7 +30,6 @@ jobs:
           path: ./weather-api
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          registry: docker.pkg.github.com
           repository: msftgbb/${{ env.IMAGE_NAME }}
           dockerfile: ./weather-api/Dockerfile
           tag_with_ref: true

--- a/.github/workflows/weather.yml
+++ b/.github/workflows/weather.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build-and-publish:
     env:
-      IMAGE_NAME: service-layer-weather-api
+      IMAGE_NAME: weather-api
     name: Build and Publish App
     runs-on: ubuntu-latest
     steps:
@@ -28,10 +28,10 @@ jobs:
         uses: docker/build-push-action@v1
         with:
           path: ./weather-api
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
           registry: docker.pkg.github.com
-          repository: cloudnativegbb/service-layer/${{ env.IMAGE_NAME }}
+          repository: msftgbb/${{ env.IMAGE_NAME }}
           dockerfile: ./weather-api/Dockerfile
           tag_with_ref: true
           add_git_labels: true


### PR DESCRIPTION
Changes packages because of fun auth issue with Github packages. (https://github.community/t/docker-pull-from-public-github-package-registry-fail-with-no-basic-auth-credentials-error/16358/32)